### PR TITLE
refactor: use reflect.TypeFor

### DIFF
--- a/testutil/nullify/nullify.go
+++ b/testutil/nullify/nullify.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	coinType  = reflect.TypeOf(sdk.Coin{})
-	coinsType = reflect.TypeOf(sdk.Coins{})
+	coinType  = reflect.TypeFor[sdk.Coin]()
+	coinsType = reflect.TypeFor[sdk.Coins]()
 )
 
 // Fill analyze all struct fields and slices with


### PR DESCRIPTION
Try to use better api reflect.TypeFor instead of reflect.TypeOf when we have known the type.
More info https://github.com/golang/go/issues/60088