### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/cmd/goatd/cmd/config.go
+++ b/cmd/goatd/cmd/config.go
@@ -50,7 +50,7 @@ func initRegtestCometBFTConfig() *cmtcfg.Config {
 
 // initAppConfig helps to override default appConfig template and configs.
 // return "", nil if no custom configuration is required for the application.
-func initAppConfig() (string, interface{}) {
+func initAppConfig() (string, any) {
 	// The following code snippet is just for reference.
 	type GoatAppConfig struct {
 		serverconfig.Config `mapstructure:",squash"`

--- a/testutil/nullify/nullify.go
+++ b/testutil/nullify/nullify.go
@@ -16,7 +16,7 @@ var (
 // Fill analyze all struct fields and slices with
 // reflection and initialize the nil and empty slices,
 // structs, and pointers.
-func Fill(x interface{}) interface{} {
+func Fill(x any) any {
 	v := reflect.Indirect(reflect.ValueOf(x))
 	switch v.Kind() {
 	case reflect.Slice:


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.